### PR TITLE
Pass through NotFoundError on get

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ module.exports = function (version, map) {
       get: function (key, cb) {
         //wait until the log has been processed up to the current point.
         db.get(key, function (err, seq) {
+          if(err && err.name === 'NotFoundError') return cb(err)
           if(err) cb(explain(err, 'flumeview-level.get: key not found:'+key))
           else
             log.get(seq, function (err, value) {


### PR DESCRIPTION
This reverts to the behavior on missing message pre v2.0.1, so that missing messages can more easily be detected.

This would fix https://github.com/ssbc/secure-scuttlebutt/issues/168