### PR TITLE
fix db recreate on index version changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -34,9 +34,8 @@ module.exports = function (version, map) {
 
     function destroy (cb) {
       close(function () {
-        Level.destroy(db, function () {
-          db = create(); cb()
-        })
+        var dbPath = path.join(path.dirname(log.filename), name)
+        Level.destroy(dbPath, cb)
       })
     }
 
@@ -125,4 +124,3 @@ module.exports = function (version, map) {
     }
   }
 }
-


### PR DESCRIPTION
fixes #2

Turns out the reason I couldn't fix this the other day was I didn't notice that the old code tried to recreate the DB twice! Once in the `destroy()` callback and again in the META check.

@dominictarr please merge! I want to update my indexes 😆