### PR TITLE
Use charwise instead of bytewise, it is much faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 var pull = require('pull-stream')
 var Level = require('level')
-var bytewise = require('bytewise')
+var charwise = require('charwise')
 var Write = require('pull-write')
 var pl = require('pull-level')
 var Obv = require('obv')
@@ -25,10 +25,8 @@ module.exports = function (version, map) {
       closed = false
       if(!log.filename)
         throw new Error('flumeview-level can only be used with a log that provides a directory')
-      return Level(path.join(dir, name), {keyEncoding: bytewise, valueEncoding: 'json'})
+      return Level(path.join(dir, name), {keyEncoding: charwise, valueEncoding: 'json'})
     }
-
-    var since = Obv()
 
     function close (cb) {
       closed = true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "bytewise": "^1.1.0",
+    "charwise": "^3.0.1",
     "explain-error": "^1.0.4",
     "level": "^1.7.0",
     "ltgt": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "git://github.com/dominictarr/flumeview-level.git"
   },
   "dependencies": {
-    "bytewise": "^1.1.0",
     "charwise": "^3.0.1",
     "explain-error": "^1.0.4",
     "level": "^1.7.0",


### PR DESCRIPTION
Benchmarks:

bytewise:

append 10000 7570.02271006813
ordered_cached 10000 9746.588693957116
random_cached 10000 4578.754578754579
ordered 10000 7955.449482895784
random_cached 10000 3086.4197530864194

charwise:

append 10000 11223.34455667789
ordered_cached 10000 13623.978201634878
random_cached 10000 4842.6150121065375
ordered 10000 11160.714285714286
random_cached 10000 6138.735420503376

I have tested this locally with a full sync and see no problems.