### PR TITLE
Improved docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Provides indexes which are persistent and can be streamed in order.
 ## example
 
 ``` js
-var ViewLevel = require('flumeview-level')
+var FlumeviewLevel = require('flumeview-level')
 
-flumedb.use(name, ViewLevel(1, function (value) {
+flumedb.use(name, FlumeviewLevel(1, function map (value) {
   return [data.foo] // must return an array
 }))
 
@@ -31,6 +31,47 @@ flumedb.append({foo: 'bar'}, function (err) {
 
 })
 ```
+
+## API
+
+### `FlumeviewLevel(version, map) => function`
+
+`version` - the version of the view. Incrementing this number will cause the view to be re-built
+
+`map` - a function with signature `(value, seq)`, where `value` is the item from the log coming past, and `seq` is the location of that value in the flume log. This function must return either: 
+  - an array of items, where each item is going to become the lookup key in the leveldb 
+    - the lookup key can be a string e.g. `address-mix` or e.g. and array `['name', '%feqasd23asd']` 
+  - empty `[]`, which signals this value will be excluded from the index 
+
+
+`function` - flumeview-level returns a function which follows the flumeview pattern, enabling it to be installed into a flumedb.
+
+
+### `get(key, cb)`
+
+This is a method that gets attached to the flumedb after you install your flumeview (see example above).
+
+
+### `read(opts) => pull-stream`
+
+`opts` is a level db query. Some example options you can include: 
+
+```js
+{
+  live: true,
+  reverse: true,
+  keys: true,
+  values: true,
+  seqs: false,
+  gte: 'name' // gte: greater than or equal to
+}
+```
+
+NOTE - if your keys are Arrays, your comparators should follow the same pattern e.g. `['name', null]` will get all keys where the first entry in the array is compared to 'name'
+
+Here are some other options you can pass which get passed to the underlying leveldb:
+https://github.com/Level/levelup#dbcreatereadstreamoptions
+
 
 ## License
 


### PR DESCRIPTION
**PATCH** - this PR just improves just the README

**WHY** - when learning to use flumeview-level I found I had to do a lot of supplementary reading and reading source code to get started. Specifically I didn't know how level worked, how queries worked or what bytewise was. I read flumeview-search to figure out how to make an index which could have more than one entry under one key without over-writing the others.

This is a real shame because the index I've just made is super tiny and super fast. Love it.
I want other devs to be able to enjoy this

After this is merged I plan to make a tutorial about flumeview-level to add to the scuttlebutt-guide.