### PR TITLE
Delete leveldb item if log item was deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = function (version, map) {
                 else cb(null, format(data.key, data.value, value))
               })
             }),
-            pull.filter(item => item != null)
+            pull.filter()
           )
           : pull.map(function (data) {
               return format(data.key, data.value, null)

--- a/index.js
+++ b/index.js
@@ -138,12 +138,12 @@ module.exports = function (version, map) {
               log.get(data.value, function (err, value) {
                 if(err) {
                   if (err.code === 'EDELETED') {
-                    return db.del(data.value, (err) => {
-                      if (err) {
-                        return cb(explain(err, `when trying to delete: ${data.key} at since ${log.since.value}`))
+                    return db.del(data.value, (delErr) => {
+                      if (delErr) {
+                        return cb(explain(delErr, `when trying to delete: ${data.key} at since ${log.since.value}`))
                       }
 
-                      cb(explain(err, `item ${data.key} has been deleted`))
+                      cb(explain(err, `harmless: item ${data.key} has been deleted`))
                     })
                   }
 

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ module.exports = function (version, map) {
               if(data.sync) return cb(null, data)
               log.get(data.value, function (err, value) {
                 if(err) {
-                  if (err.code === 'EDELETED') {
+                  if (err.code === 'flumelog:deleted') {
                     return db.del(data.key, (delErr) => {
                       if (delErr) {
                         return cb(explain(err, 'when trying to delete:'+data.key+'at since:'+log.since.value))
@@ -157,7 +157,7 @@ module.exports = function (version, map) {
           )
           : pull.map(function (data) {
               return format(data.key, data.value, null)
-          }),
+          })
         )
       },
       close: close,

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = function (version, map) {
               log.get(data.value, function (err, value) {
                 if(err) {
                   if (err.code === 'EDELETED') {
-                    return db.del(data.value, (delErr) => {
+                    return db.del(data.key, (delErr) => {
                       if (delErr) {
                         return cb(explain(err, 'when trying to delete:'+data.key+'at since:'+log.since.value))
                       }

--- a/index.js
+++ b/index.js
@@ -136,7 +136,19 @@ module.exports = function (version, map) {
           ? Paramap(function (data, cb) {
               if(data.sync) return cb(null, data)
               log.get(data.value, function (err, value) {
-                if(err) cb(explain(err, 'when trying to retrive:'+data.key+'at since:'+log.since.value))
+                if(err) {
+                  if (err.code === 'EDELETED') {
+                    return db.del(data.value, (err) => {
+                      if (err) {
+                        return cb(explain(err, `when trying to delete: ${data.key} at since ${log.since.value}`))
+                      }
+
+                      cb(explain(err, `item ${data.key} has been deleted`))
+                    })
+                  }
+
+                  cb(explain(err, 'when trying to retrive:'+data.key+'at since:'+log.since.value))
+                }
                 else cb(null, format(data.key, data.value, value))
               })
             })

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "flumecodec": "0.0.1",
     "flumedb": "^1.0.0",
     "flumelog-offset": "^3.2.6",
+    "tape": "^4.10.1",
     "test-flumeview-index": "^2.2.0"
   },
   "scripts": {


### PR DESCRIPTION
This deletes items that return an error with code `EDELETED`, see: https://github.com/flumedb/flumelog-offset/pull/17/commits/671459b720d18512f01c42870728eafbaa28e703