### PR TITLE
Upgrade to leveldb@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "charwise": "^3.0.1",
     "explain-error": "^1.0.4",
-    "level": "^4.0.0",
+    "level": "^5.0.1",
     "ltgt": "^2.1.3",
     "mkdirp": "^0.5.1",
     "obv": "0.0.1",
@@ -23,6 +23,7 @@
     "flumecodec": "0.0.1",
     "flumedb": "^1.0.0",
     "flumelog-offset": "^3.2.6",
+    "tape": "^4.10.1",
     "test-flumeview-index": "^2.2.0"
   },
   "scripts": {


### PR DESCRIPTION
Exactly what it says on the tin.

...also installs tape as a devdep because it was missing.