### PR TITLE
Always pass errors on deleted messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,10 +107,10 @@ module.exports = function (version, map) {
               if (err.code === 'flumelog:deleted') {
                 return db.del(key, (delErr) => {
                   if (delErr) {
-                    return cb(explain(err, 'when trying to delete:'+key+'at since:'+log.since.value))
+                    return cb(explain(delErr, 'when trying to delete:'+key+'at since:'+log.since.value))
                   }
 
-                  cb(null, null, seq)
+                  cb(err, null, seq)
                 })
               }
 


### PR DESCRIPTION
Otherwise clients don't know why they aren't getting the deleted message.